### PR TITLE
Enable backspace

### DIFF
--- a/mixin.js
+++ b/mixin.js
@@ -40,6 +40,11 @@ var ReactMaskMixin = {
       this.mask.cursor,
       this.mask.cursor
     )
+    
+    if (document.selection) {
+      var selection = document.selection.createRange()
+      selection.moveStart('character', this.mask.cursor)
+    }
   },
 
   processValue: function(value) {


### PR DESCRIPTION
Today, it's impossible to simply erase characters using backspace. So I did this little patch to fix this behavior.
